### PR TITLE
Fixes link to Burlington Ruby Conference

### DIFF
--- a/index.html
+++ b/index.html
@@ -669,7 +669,7 @@ END
 
     <p>Conferences began to develop codes of conduct, rules and algorithms for people (men, really) to follow. </p>
 
-    <p class="indent">If you are subject to or witness unacceptable behavior, or have any other concerns, please notify a community organizer as soon as possible &hellip;  <br/>&mdash;<em><a target="_blank" href="http://www.burlingtonrubyconference.com/conduct.html">Burlington Ruby Conference</a></em></p>
+    <p class="indent">If you are subject to or witness unacceptable behavior, or have any other concerns, please notify a community organizer as soon as possible &hellip;  <br/>&mdash;<em><a target="_blank" href="http://www.burlingtonrubyconference.com/conduct">Burlington Ruby Conference</a></em></p>
 
     <p class="indent">php[architect] is dedicated to providing a harassment-free event experience for everyone and will not tolerate harassment or offensive behavior in any form. 
                          <br/>&mdash;<em><a target="_blank" href="http://www.phparch.com/policies/code-of-conduct/">php[architect]</a></em></p>


### PR DESCRIPTION
The URI of the Burlington Ruby Conference code of conduct doesn't end in `.html`. :)