### PR TITLE
Don't require pop() to remove pugs

### DIFF
--- a/modules/learninal/learninal.js
+++ b/modules/learninal/learninal.js
@@ -91,7 +91,7 @@
   { "speak": "Now get rid of pugs. The way you do that is by calling the pop method: dogs.pop();" },
   {
     "test": function(item) {
-      if(dogs.length == 4 && item.result=="pug" && item.command.indexOf("pop") !== -1) {
+      if(dogs.length == 4 && item.result=="pug") {
         this.emote("love");
         return true;
       } else {


### PR DESCRIPTION
You can remove pugs from the JS array using splice just as well! There isn't really any reason to hardwire it to only accept `pop` if the job gets done, right? I just removed the test for `pop`, checking whether the array is the right length and the return value was pug.