### PR TITLE
Fixed Fortran code so it compiles.

### DIFF
--- a/index.html
+++ b/index.html
@@ -398,8 +398,8 @@
 
     <p>Or maybe:</p>
 
-<pre><code class="fortran">PRINT *, "WHY WON'T IT WORK
-END
+<pre><code class="fortran">      PRINT *, "WHY WON'T IT WORK
+      END
 </code>
 </pre>
 


### PR DESCRIPTION
Columns 1-5 in Fortran are the label field, and column 6 is the
continuation field.  As written, the code fails to compile once
fixed according to the article:

```
$ gfortran -o /dev/null whatiscode.f
whatiscode.f:1.1:

PRINT *, "WHY WON'T IT WORK"
 1
Error: Non-numeric character in statement label at (1)
whatiscode.f:1.1:

PRINT *, "WHY WON'T IT WORK"
 1
Error: Unclassifiable statement at (1)
whatiscode.f:2.1:

END
 1
Error: Non-numeric character in statement label at (1)
whatiscode.f:2.1:

END
 1
Error: Unclassifiable statement at (1)
```

It works properly after moving the code to the correct location:

```
$ cat whatiscode.f
      PRINT *, "WHY WON'T IT WORK"
      END
$ gfortran -o whatiscode whatiscode.f
$ ./whatiscode
 WHY WON'T IT WORK
```