### PR TITLE
Compare location.pathname >= 0

### DIFF
--- a/modules/grabbag/grabbag.js
+++ b/modules/grabbag/grabbag.js
@@ -1,10 +1,9 @@
 !(function(){
 
   //check on load to see if you need to be dragged back after wrecking
-  if (location.href.indexOf('grabbag')){
+  if (location.pathname.indexOf('grabbag') >= 0){
     setTimeout(function(){
-      scrollTo(0, d3.select('#grabbag').node().getBoundingClientRect().top + pageYOffset - 100)    
-      console.log("asdfasdfasdf")
+      scrollTo(0, d3.select('#grabbag').node().getBoundingClientRect().top + pageYOffset - 100)
     }, 1500)
   }
 

--- a/modules/grabbag/grabbag.js
+++ b/modules/grabbag/grabbag.js
@@ -1,7 +1,7 @@
 !(function(){
 
   //check on load to see if you need to be dragged back after wrecking
-  if (location.pathname.indexOf('grabbag') >= 0){
+  if (location.hash.indexOf('grabbag') > 0){
     setTimeout(function(){
       scrollTo(0, d3.select('#grabbag').node().getBoundingClientRect().top + pageYOffset - 100)
     }, 1500)
@@ -66,7 +66,7 @@
           "onbrush": function(value) {
             var scale = d3.scale.threshold()
               .domain([1/8,2/8,3/8,4/8,5/8,6/8,7/8])
-              .range(['love', 'jumps', 'waving', 'chill', 'angry', 'angry2', 'angry3', 'angry4']); 
+              .range(['love', 'jumps', 'waving', 'chill', 'angry', 'angry2', 'angry3', 'angry4']);
             module.bot.emote(scale(value));
             return true;
           },
@@ -127,7 +127,7 @@
     if(!direction) {
       d3.selectAll("img")
         .attr("src", function(d){
-          return this.getAttribute('data-src') || this.getAttribute('src') 
+          return this.getAttribute('data-src') || this.getAttribute('src')
         })
 
       return;
@@ -195,7 +195,7 @@
       } else {
         textNode.nodeValue = fixText(textNode.nodeValue);
       }
-      
+
     }
 
     function replaceText(v)


### PR DESCRIPTION
The String.prototype.indexOf method returns `-1` if the value isn't found as a substring, not `false`. Since `!!-1 === true` in JavaScript, this means that the only condition where the user isn't forced to scroll would be if `location.href.indexOf('grabbag') == 0`, which isn't going to happen unless we're using using a weird protocol handler like `grabbag://` or instead of HTTP(S)/FTP/etc.

![35mpy](https://cloud.githubusercontent.com/assets/537700/8119029/6ce25e1e-1047-11e5-8583-800632b63f80.png)

Secondly, this commits uses `location.pathname` to ignore both the protocol handler and the domain, which is just more surface area for bugs (especially if we're changing `/etc/hosts` or anything for local testing).

Compare [`location.href`](https://developer.mozilla.org/en-US/docs/Web/API/URLUtils/hrefhttps://developer.mozilla.org/en-US/docs/Web/API/URLUtils/href) to [`location.pathname`](https://developer.mozilla.org/en-US/docs/Web/API/URLUtils/pathname) for more info.

Lastly, this commit removes the garbage `console.log` for debugging in production. It looks like I also removed some whitespace appended to a few expressions expression, but I doubt they were intentional.