### PR TITLE
[highlightTooltip] Do not show popup if codeClass value is undefined

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -111,6 +111,8 @@ function highlightTooltip(e) {
     "hljs-variable": "A variable"
   }
 
+  if(typeof codeClasses[codeClass] === 'undefined') return;
+
   var popup = d3.select("body").selectAll(".syntax-tooltip").data([codeClass]);
   popup.enter().append("div").classed("syntax-tooltip", true);
   popup.text(codeClasses[codeClass])


### PR DESCRIPTION
Plane text in HTML code does not get any hljs class, so returns `undefined` for `codeClasses[codeClass]` causing blank popup to show up at the bottom.
If no class is defined in `codeClasses` object, it should it should avoid appending popup div.

![highlightTooltip_bug](https://cloud.githubusercontent.com/assets/4581495/8123265/112d2da4-1094-11e5-85b7-e705077cc0d2.png)