### PR TITLE
Let the cowboys go home; fixes #26

### DIFF
--- a/modules/grabbag/grabbag.js
+++ b/modules/grabbag/grabbag.js
@@ -128,13 +128,13 @@
       d3.selectAll("img")
         .attr("src", function(d){
           return this.getAttribute('data-src') || this.getAttribute('src')
-        })
+        }).attr("data-src", null);
 
       return;
     }
 
     d3.selectAll("img")
-      .attr("data-src", function(d) { return this.getAttribute('src'); })
+      .attr("data-src", function(d) {return this.getAttribute('data-src') || this.getAttribute('src'); })
       .attr("src", "images/cowboy_on_computer.gif");
 
     module.bot.dialogue([


### PR DESCRIPTION
Fixes #26 

-Don't overwrite data-src with src if data-src already exists
-Removes data-src after images are reset

Much like the cowboys, this code is a bit on the dangerous side.
If an img has a data-src attribute added anywhere else on the page,
it may never get replaced with a cowboy. If anything else touches
the data-src attribute after the original src is cached, the
cowboy may never leave