### PR TITLE
Removed "random" referring to git commit ids

### DIFF
--- a/index.html
+++ b/index.html
@@ -2348,7 +2348,7 @@ class Book(models.Model):
 
       <p>A change comes in a few seconds later from a coder far away; doesn&rsquo;t matter to Version 3. You&rsquo;re done with Version 3. Version 3 is part of the permanent record. You might fix some bugs and call that Version 3.1. You might add another feature and call it Version 4.</p>
 
-      <p>Tools such as git give programmers a common language. &ldquo;Did you check that in?&rdquo; they ask. &ldquo;Which commit was that?&rdquo; &ldquo;That was going to be in 2.4, but we pushed it to 2.5.&rdquo; Because each commit gets a random, unique identifier, you can pinpoint that commit in space and time and feel confident in the record of code changes in a way that you can rarely feel confident about anything.</p>
+      <p>Tools such as git give programmers a common language. &ldquo;Did you check that in?&rdquo; they ask. &ldquo;Which commit was that?&rdquo; &ldquo;That was going to be in 2.4, but we pushed it to 2.5.&rdquo; Because each commit gets a unique identifier, you can pinpoint that commit in space and time and feel confident in the record of code changes in a way that you can rarely feel confident about anything.</p>
 
       <p>A side effect of this confidence is increased automation. Let&rsquo;s say you have a Web server program that&rsquo;s very popular and serves hundreds of millions of people every month. It runs on 50 different computers on the cloud. Aren&rsquo;t you something.</p>
 


### PR DESCRIPTION
git commit hashes/ids are unique but not random (see links in #70 for details)

Fixes #70 