### PR TITLE
Fix 'Stack Overlow' typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -701,7 +701,7 @@
     <p>Which leads one to the inescapable conclusion: The problem with women in technology isn&rsquo;t the women.</p>
     
     <div class="bigimgWrap" id="demographics">
-      <div style='font-size: 13px'>Some demographics taken from Stack Overlow's 2015 developer survey:</div>
+      <div style='font-size: 13px'>Some demographics taken from Stack Overflow's 2015 developer survey:</div>
       <img class="centered" src="images/sec1_demographics.jpg"></img>
     </div>
 


### PR DESCRIPTION
Minor typo of 'Stack Overflow' as 'Stack Overlow'.