### PR TITLE
Better PostScript sample

### DIFF
--- a/index.html
+++ b/index.html
@@ -565,10 +565,11 @@
          </sup> the language of laser printers, came after Forth but is much like it. Look at how similar the code is, give or take some squiggles:</p>
     
 <pre><code class="nohighlight postscript">/gcd {
-{
-  {0 gt} {dup rup mod} {pop exit} ifte
-} loop
-}.</code></pre>
+   dup 0 ne {
+      dup 3 1 roll mod gcd
+   } { pop } ifelse
+} def
+</code></pre>
 
     <p>And that&rsquo;s Euclid&rsquo;s algorithm in PostScript. I admit, this might be fun only for me. Here it is in Python (all credit to Rosetta Code):</p>
 


### PR DESCRIPTION
The given sample won't work on a vanilla PostScript. It's better to use the second example given on [RosettaCode](http://rosettacode.org/wiki/Greatest_common_divisor#PostScript).

``` PostScript
/gcd {
   dup 0 ne {
      dup 3 1 roll mod gcd
   } { pop } ifelse
} def
```

If you have GhostScript installed, then this will do the job:

```
GPL Ghostscript 9.16 (2015-03-30)
Copyright (C) 2015 Artifex Software, Inc.  All rights reserved.
This software comes with NO WARRANTY: see the file PUBLIC for details.
GS>/gcd {
   dup 0 ne {
      dup 3 1 roll mod gcd
   } { pop } ifelse
} def
GS>695 340 gcd =
5
```
