### PR TITLE
Change Spelling of "Cal Tech" to "Caltech"

### DIFF
--- a/index.html
+++ b/index.html
@@ -1365,7 +1365,7 @@ $ ./a.out</code></pre>
 
 <h3><span class="section">4.1</span> The Legend of the 10x Programmer</h3>
 
-    <p>Programming has twin cults of genius and youth. One of the ways Google acquired its reputation was by hiring fresh-faced whizzes. Ph.D.s from Stanford, Cal Tech, MIT, and Carnegie Mellon were table stakes. The true programmer began to code in utero and has an IQ of at least 10,000.</p>
+    <p>Programming has twin cults of genius and youth. One of the ways Google acquired its reputation was by hiring fresh-faced whizzes. Ph.D.s from Stanford, Caltech, MIT, and Carnegie Mellon were table stakes. The true programmer began to code in utero and has an IQ of at least 10,000.</p>
 
     <p>There&rsquo;s even the legend of the 10x programmer, an individual who is just that much more productive than the proletariat. There is evidence that some programmers are much more productive than their equally experienced peers; but other studies have found this to be engineering folklore. Ten is an order of magnitude in a discipline that uses orders of magnitude to estimate things. Ten is an attractive and thus suspicious number.</p>
 


### PR DESCRIPTION
Addresses #110: https://github.com/BloombergMedia/whatiscode/issues/110

Correct spelling verified on: http://www.caltech.edu/

Great article!