### PR TITLE
firefox fixes for Heading permalinks #46

### DIFF
--- a/modules/toc/toc.js
+++ b/modules/toc/toc.js
@@ -181,12 +181,12 @@ var stats,
       .append("a.toc-head")
       .attr("data-level", ƒ('tagName'))
       .attr("href", function(d) { return '#' + d.id; })
-      .html(function(d) { return d.childNodes[0].innerText + ". " + d.childNodes[1].nodeValue; })
+      .html(function(d) { return d.childNodes[0].textContent + ". " + d.childNodes[1].nodeValue; })
       .on("click", function(d) {
         d3.event.preventDefault();
         history.pushState(null, null, '#'+d.id);
-        stats.windows.previous = stats.windows.current; 
-        d3.select("body").transition().duration(500)
+        stats.windows.previous = stats.windows.current;
+        d3.select("body, html").transition().duration(500)
           .tween("tocscroll", scrollTopTween(d.getBoundingClientRect().top + pageYOffset));
       });
   }


### PR DESCRIPTION
Firefox fixes for Heading permalinks, issue #46 
https://github.com/BloombergMedia/whatiscode/issues/46

Tested on:
OS X: Firefox 43, Chrome 47