### PR TITLE
Deleted comma

### DIFF
--- a/index.html
+++ b/index.html
@@ -1326,7 +1326,7 @@ The original version of this story incorrectly stated $2 billion. <em><a href="h
 
 <h2 id="the-time-you-attended-the-e-mail-address-validation-meeting"><a href="#the-time-you-attended-the-e-mail-address-validation-meeting">5</a> The Time You Attended the E-mail Address Validation Meeting</h2>
 
-<p>In the interest of understanding more about how all this works, and with an open invitation from TMitTB, you attend a meeting of the programmers.</p>
+<p>In the interest of understanding more about how all this works and with an open invitation from TMitTB, you attend a meeting of the programmers.</p>
 
 <p>Two of them are late, and bravely you ask the one already in attendance to explain what&rsquo;s going on. He quickly gathers the limits of your information through a series of questions, beginning with, &ldquo;Do you know what a Web page is?&rdquo; </p>
 


### PR DESCRIPTION
Support for the edit:
[Grammarly: Comma before "and"](https://www.grammarly.com/blog/comma-before-and/)

Thank you for the beautiful article and your contentious work to improve it!

Leo